### PR TITLE
Make v4 Kernel account address deterministic (drop wall-clock timestamp policy)

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,7 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/test'],
+  testTimeout: 30000,
+};

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   ],
   "scripts": {
     "build": "tsc",
+    "test": "jest",
     "clean": "rm -rf dist",
     "lint": "eslint src --ext .ts",
     "example": "ts-node examples/basic-workflow.ts",

--- a/src/core/builders/PermissionBuilder.ts
+++ b/src/core/builders/PermissionBuilder.ts
@@ -5,7 +5,6 @@ import {
     CallPolicyVersion,
     ParamCondition,
     toRateLimitPolicy,
-    toTimestampPolicy,
     toSudoPolicy,
 } from "@zerodev/permissions/policies";
 import { DittoWFRegistryAbi } from '../../utils/constants';
@@ -209,21 +208,15 @@ export function buildPolicies(workflow: Workflow, prodContract: boolean, job: Jo
             }));
         }
     }
-    if (workflow.validUntil) {
-        if (workflow.validAfter) {
-            policies.push(toTimestampPolicy({
-                validAfter: Math.floor(workflow.validAfter.getTime() / 1000),
-                validUntil: Math.floor(workflow.validUntil.getTime() / 1000),
-            }));
-        } else {
-            policies.push(toTimestampPolicy({
-                validUntil: Math.floor(workflow.validUntil.getTime() / 1000),
-            }));
-        }
-    } else if (workflow.validAfter) {
-        policies.push(toTimestampPolicy({
-            validAfter: Math.floor(workflow.validAfter.getTime() / 1000),
-        }));
-    }
+    // The validity window (validAfter/validUntil) is deliberately NOT installed as an
+    // on-chain timestamp policy. A timestamp policy built from the wall-clock window would
+    // become part of the permission set -> permissionId -> toInitConfig() -> the CREATE2
+    // Kernel account address, so every submit at a different second would derive a different
+    // counterfactual account (which then can't be pre-funded, and registering != executing
+    // account within a single submit). Keeping it out makes the account a stable function of
+    // (owner, executor, call-permissions, rate-limit) only. The window is still enforced
+    // off-chain: it is serialized into the IPFS workflow payload (WorkflowSerializer) and the
+    // Ditto AVS only attests/executes inside it, while the on-chain rate-limit policy
+    // (count/interval) bounds total executions.
     return policies;
 } 

--- a/test/account-derivation.integration.test.ts
+++ b/test/account-derivation.integration.test.ts
@@ -1,0 +1,85 @@
+import { WorkflowBuilder, JobBuilder, ChainId, serialize, getChainConfig } from '../src';
+import { Workflow } from '../src';
+import { addressToEmptyAccount, createKernelAccount } from '@zerodev/sdk';
+import { signerToEcdsaValidator } from '@zerodev/ecdsa-validator';
+import { getEntryPoint, KERNEL_V3_3 } from '@zerodev/sdk/constants';
+import { privateKeyToAccount } from 'viem/accounts';
+import { createPublicClient, http } from 'viem';
+
+// End-to-end regression for the v4 non-deterministic account-derivation bug.
+// Needs a reachable RPC, so it is gated behind DITTO_IPFS_SERVICE_URL (the SDK derives
+// rpcUrl as `${ipfsServiceUrl}/bundler/${chainId}`). All calls are read-only address
+// derivation (eth_call) — no gas, no submission. Run with:
+//   DITTO_IPFS_SERVICE_URL=http://46.101.223.202:8080 npm test
+const IPFS_SERVICE_URL = process.env.DITTO_IPFS_SERVICE_URL;
+const EXECUTOR = '0xE295E078f233D48e5C734207EAe043Dd4FDf95f7' as const;
+// Throwaway, well-known test key (anvil/hardhat #0). NOT a production owner key.
+const TEST_OWNER_KEY = '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80' as const;
+const CHAINLINK_FEED = '0x4aDC67696bA383F43DD60A9e78F2C97Fbbfc7cb1' as const;
+const ANCHOR = 1_700_000_000_000;
+
+function decodeSessionAccount(sessionStr: string): string {
+  const base64 = sessionStr.replace(/-/g, '+').replace(/_/g, '/');
+  const padded = base64 + '='.repeat((4 - (base64.length % 4)) % 4);
+  const decoded = JSON.parse(Buffer.from(padded, 'base64').toString('utf-8'));
+  return (decoded.accountParams.accountAddress as string).toLowerCase();
+}
+
+const maybe = IPFS_SERVICE_URL ? describe : describe.skip;
+
+maybe('v4 account derivation determinism (integration — needs DITTO_IPFS_SERVICE_URL)', () => {
+  const owner = privateKeyToAccount(TEST_OWNER_KEY);
+
+  function makeWorkflow(validAfterMs: number, validUntilMs: number): Workflow {
+    const wf = WorkflowBuilder.create(addressToEmptyAccount(owner.address))
+      .addCronTrigger('*/2 * * * *')
+      .setCount(5)
+      .setInterval(120)
+      .setValidAfter(new Date(validAfterMs))
+      .setValidUntil(new Date(validUntilMs))
+      .addJob(
+        JobBuilder.create('job-1')
+          .setChainId(ChainId.BASE_SEPOLIA)
+          .addStep({ target: CHAINLINK_FEED, abi: 'latestRoundData()', args: [], value: BigInt(0) })
+          .build(),
+      )
+      .build();
+    wf.typify();
+    return wf;
+  }
+
+  test('serialize() yields the same session account regardless of the validity window', async () => {
+    const a = await serialize(makeWorkflow(ANCHOR, ANCHOR + 60 * 60 * 1000), EXECUTOR, owner, false, IPFS_SERVICE_URL!);
+    const b = await serialize(
+      makeWorkflow(ANCHOR + 9_999 * 1000, ANCHOR + 7 * 24 * 60 * 60 * 1000),
+      EXECUTOR, owner, false, IPFS_SERVICE_URL!,
+    );
+
+    const accA = decodeSessionAccount(a.data.workflow.jobs[0].session);
+    const accB = decodeSessionAccount(b.data.workflow.jobs[0].session);
+
+    expect(accB).toEqual(accA);
+  });
+
+  test('session account (executing) === createWorkflow sender (registering)', async () => {
+    const { data, initConfigs } = await serialize(
+      makeWorkflow(ANCHOR, ANCHOR + 60 * 60 * 1000), EXECUTOR, owner, false, IPFS_SERVICE_URL!,
+    );
+    const sessionAccount = decodeSessionAccount(data.workflow.jobs[0].session);
+
+    // Replicate WorkflowContract.createWorkflow's account derivation (same initConfig + owner).
+    const job = data.workflow.jobs[0];
+    const cfg = getChainConfig(IPFS_SERVICE_URL!)[job.chainId];
+    const publicClient = createPublicClient({ transport: http(cfg.rpcUrl), chain: cfg.chain });
+    const entryPoint = getEntryPoint('0.7');
+    const ownerValidator = await signerToEcdsaValidator(publicClient, { entryPoint, signer: owner, kernelVersion: KERNEL_V3_3 });
+    const registering = await createKernelAccount(publicClient, {
+      plugins: { sudo: ownerValidator },
+      entryPoint,
+      kernelVersion: KERNEL_V3_3,
+      initConfig: initConfigs.get(job.chainId),
+    });
+
+    expect(registering.address.toLowerCase()).toEqual(sessionAccount);
+  });
+});

--- a/test/account-derivation.test.ts
+++ b/test/account-derivation.test.ts
@@ -1,0 +1,69 @@
+import { WorkflowBuilder, JobBuilder, ChainId } from '../src';
+import { Workflow } from '../src';
+import { addressToEmptyAccount } from '@zerodev/sdk';
+import { buildPolicies } from '../src/core/builders/PermissionBuilder';
+
+const OWNER = '0x1111111111111111111111111111111111111111' as const;
+// Base Sepolia Chainlink ETH/USD feed — an arbitrary call target.
+const TARGET_A = '0x4aDC67696bA383F43DD60A9e78F2C97Fbbfc7cb1' as const;
+const TARGET_B = '0x694AA1769357215DE4FAC081bf1f309aDC325306' as const;
+
+function makeWorkflow(
+  validAfterMs: number,
+  validUntilMs: number,
+  target: string = TARGET_A,
+): Workflow {
+  const wf = WorkflowBuilder.create(addressToEmptyAccount(OWNER))
+    .addCronTrigger('*/2 * * * *')
+    .setCount(5)
+    .setInterval(120)
+    // Pass Date objects so the builder's "must be in the future" guard (number path)
+    // is bypassed — keeps these timestamps fixed and the test reproducible forever.
+    .setValidAfter(new Date(validAfterMs))
+    .setValidUntil(new Date(validUntilMs))
+    .addJob(
+      JobBuilder.create('job-1')
+        .setChainId(ChainId.BASE_SEPOLIA)
+        .addStep({ target: target as `0x${string}`, abi: 'latestRoundData()', args: [], value: BigInt(0) })
+        .build(),
+    )
+    .build();
+  wf.typify();
+  return wf;
+}
+
+// The on-chain identity of the session permission validator: for each policy,
+// (policyFlag+policyAddress) ++ policyData. This is exactly the byte material that
+// feeds permissionId -> toInitConfig -> the CREATE2 Kernel account address. If this
+// is byte-identical across two builds, the derived counterfactual account is identical.
+function policyIdentity(policies: ReturnType<typeof buildPolicies>): string {
+  return policies
+    .map((p) => `${p.getPolicyInfoInBytes()}:${p.getPolicyData()}`)
+    .join('|');
+}
+
+describe('v4 Kernel account derivation determinism', () => {
+  // Fixed, deterministic anchor (Nov 2023). Never compared against Date.now().
+  const ANCHOR = 1_700_000_000_000;
+
+  test('account-determining policies are independent of the wall-clock validity window', () => {
+    const wfEarly = makeWorkflow(ANCHOR, ANCHOR + 60 * 60 * 1000); // 1h window
+    // Same logical workflow, "submitted" ~3.4h later with a 7-day window.
+    const wfLate = makeWorkflow(ANCHOR + 12_345 * 1000, ANCHOR + 7 * 24 * 60 * 60 * 1000);
+
+    const idEarly = policyIdentity(buildPolicies(wfEarly, true, wfEarly.jobs[0]));
+    const idLate = policyIdentity(buildPolicies(wfLate, true, wfLate.jobs[0]));
+
+    expect(idLate).toEqual(idEarly);
+  });
+
+  test('account-determining policies still depend on the call target (not over-removed)', () => {
+    const wfA = makeWorkflow(ANCHOR, ANCHOR + 60 * 60 * 1000, TARGET_A);
+    const wfB = makeWorkflow(ANCHOR, ANCHOR + 60 * 60 * 1000, TARGET_B);
+
+    const idA = policyIdentity(buildPolicies(wfA, true, wfA.jobs[0]));
+    const idB = policyIdentity(buildPolicies(wfB, true, wfB.jobs[0]));
+
+    expect(idB).not.toEqual(idA);
+  });
+});


### PR DESCRIPTION
## Problem

After #78 moved the session-permission install into `initConfig` (the canonical ZeroDev pattern), the **entire policy set** feeds `permissionId → toInitConfig → createKernelAccount` — i.e. the CREATE2 account address. `buildPolicies()` was pushing a `toTimestampPolicy` built from the workflow's wall-clock `validAfter`/`validUntil` (`setValidUntil(Date.now()+…)`), so:

- **Every submit at a different second derived a different counterfactual account.** It could never be pre-funded → `eth_estimateUserOperationGas` reverts **`AA21 didn't pay prefund`**. v4 `submitWorkflow` was unusable on mainnet.
- **Within one submit, the registering account ≠ the executing account** (`createWF` sender vs the session's encoded account), so `markRun` (`onlyWorkflowOwner`) would revert even if funded.

Verified at the byte level: the wall-clock `validAfter`/`validUntil` were literally present in the live userOp `factoryData` (the address preimage). Across the investigation the same workflow produced 10+ distinct addresses, and rebuilding with a fixed `validAfter` reproduced a prior address exactly — confirming the wall-clock second is the sole non-deterministic input (the call, sudo/DittoPolicy, and rate-limit `startAt=0` policies are byte-identical across submits).

## Fix

Remove the timestamp policy from `buildPolicies`. The account is now a function of **(owner, executor, call-permissions, rate-limit)** only. This matches ZeroDev's canonical `install-permissions-with-init-config.ts`, which carries no timestamp policy.

The validity window is **not** lost: it's still serialized into the IPFS payload (`WorkflowSerializer`), still enforced off-chain (`Workflow.isExpired()`, `WorkflowValidator`), and bounded by the AVS (which won't attest outside it) plus the on-chain rate-limit policy. Time-based **triggers** (cron schedule) are unrelated to this policy and unchanged.

### Tradeoff (please ratify)
On-chain **session expiry** is removed. It was redundant defense-in-depth — the gate that matters is the hook's `isApprovedUserOpHash` (only AVS-attested hashes), plus rate-limit + nonce, and the guard workflow already used a `now+15y` window. If on-chain expiry must stay, the alternative is to set an **absolute** `validUntil` (fixed at creation, not `Date.now()+delta`) so the timestamp policy is deterministic — at the cost of making the window part of account identity.

## Tests (`test/account-derivation*.ts`, jest)
- Offline: the account-determining policy set is independent of the validity window, and still depends on the call target (not over-removed).
- Live (Base Sepolia, gated on `DITTO_IPFS_SERVICE_URL`): `serialize()` yields the same session account across different windows, and that account equals the `createWorkflow` sender.
- **RED before this change, GREEN after** (verified both directions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)