### PR TITLE
v4 SDK hardening: per-job initConfig, drop Optimism, expiry guard, CI, lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ main, develop ]
+    branches: [ master, develop ]
   pull_request:
-    branches: [ main ]
+    branches: [ master ]
 
 jobs:
   test:
@@ -30,4 +30,7 @@ jobs:
       run: npm run lint
     
     - name: Build
-      run: npm run build 
+      run: npm run build
+
+    - name: Test
+      run: npm test

--- a/src/core/Workflow.ts
+++ b/src/core/Workflow.ts
@@ -129,7 +129,7 @@ export class Workflow implements IWorkflow {
         try {
           const parsed = JSON.parse(val);
           if (Array.isArray(parsed)) return parsed;
-        } catch { }
+        } catch { /* not valid JSON array, fall through to raw value */ }
         return val;
       }
       return val;
@@ -161,7 +161,7 @@ export class Workflow implements IWorkflow {
             if (fn.outputs && fn.outputs.length > 0) {
               returnType = fn.outputs[0].type;
             }
-          } catch { }
+          } catch { /* abi parse failed, keep default returnType */ }
 
           let condOp = onchainCondition.condition;
           if (typeof condOp === 'string') {

--- a/src/core/builders/PermissionBuilder.ts
+++ b/src/core/builders/PermissionBuilder.ts
@@ -5,7 +5,6 @@ import {
     CallPolicyVersion,
     ParamCondition,
     toRateLimitPolicy,
-    toSudoPolicy,
 } from "@zerodev/permissions/policies";
 import { DittoWFRegistryAbi } from '../../utils/constants';
 import { getDittoWFRegistryAddress, getDittoPolicyAddress } from '../../utils/chainConfigProvider';

--- a/src/core/builders/WorkflowSerializer.ts
+++ b/src/core/builders/WorkflowSerializer.ts
@@ -3,7 +3,7 @@ import { Signer } from "@zerodev/sdk/types";
 import { addressToEmptyAccount } from "@zerodev/sdk";
 import { SerializedWorkflowData } from '../../storage/IWorkflowStorage';
 import { Workflow } from '../Workflow';
-import { createSession, SessionResult } from './SessionService';
+import { createSession } from './SessionService';
 import { SerializedWorkflowDataSchema } from '../validation/WorkflowSchema';
 import { WorkflowError, WorkflowErrorCode } from '../WorkflowError';
 import { OnchainConditionOperator, type Step as IStep, type Job as IJob } from '../types';
@@ -35,69 +35,12 @@ function conditionStringToEnum(text: string): OnchainConditionOperator {
     }
 }
 
-function extractInputTypesFromAbiSignature(signature: string): string[] {
-    const match = signature.match(/^\s*[^\s(]+\s*\(([^)]*)\)/);
-    if (!match) {
-        return [];
-    }
-    const params = match[1].trim();
-    if (params.length === 0) {
-        return [];
-    }
-    return params
-        .split(',')
-        .map(p => p.trim())
-        .filter(p => p.length > 0)
-        .map(p => {
-            const firstSpace = p.indexOf(' ');
-            return (firstSpace === -1 ? p : p.slice(0, firstSpace)).trim();
-        });
-}
-
-// Data reference prefix - values starting with this should not be coerced
-const DATA_REF_PREFIX = '$ref:';
-
-function coerceArgToType(raw: any, type: string): any {
-    if (raw === null || raw === undefined) return raw;
-    // Skip coercion for data references - they will be resolved at execution time
-    if (typeof raw === 'string' && raw.startsWith(DATA_REF_PREFIX)) return raw;
-    const lower = type.toLowerCase();
-    if (lower === 'bool') {
-        if (typeof raw === 'boolean') return raw;
-        if (typeof raw === 'string') return raw.toLowerCase() === 'true';
-        return Boolean(raw);
-    }
-    if (lower.startsWith('uint') || lower.startsWith('int')) {
-        if (typeof raw === 'bigint') return raw;
-        if (typeof raw === 'number') return BigInt(raw);
-        if (typeof raw === 'string') return BigInt(raw);
-        return BigInt(raw as any);
-    }
-    if (lower === 'address') {
-        return String(raw) as any;
-    }
-    if (lower === 'string') {
-        return String(raw);
-    }
-    if (lower.startsWith('bytes')) {
-        return String(raw);
-    }
-    return raw;
-}
-
-function coerceArgsByAbi(signature: string, rawArgs: any[]): any[] {
-    try {
-        const types = extractInputTypesFromAbiSignature(signature);
-        if (types.length === 0) return rawArgs;
-        return rawArgs.map((arg, idx) => coerceArgToType(arg, types[Math.min(idx, types.length - 1)]));
-    } catch {
-        return rawArgs;
-    }
-}
-
 export interface SerializeResult {
     data: SerializedWorkflowData;
-    initConfigs: Map<number, `0x${string}`[]>; // chainId -> initConfig
+    // One initConfig per job, aligned by index with `data.workflow.jobs`. Keyed by index
+    // (not chainId) so multiple jobs on the same chain don't collide — each job has its own
+    // session account, hence its own initConfig.
+    initConfigs: `0x${string}`[][];
 }
 
 export async function serialize(
@@ -110,13 +53,13 @@ export async function serialize(
     accessToken?: string,
 ): Promise<SerializeResult> {
     const jobs: any[] = [];
-    const initConfigs = new Map<number, `0x${string}`[]>();
+    const initConfigs: `0x${string}`[][] = [];
     for (const job of workflow.jobs) {
         if (switchChain) {
             await switchChain(job.chainId);
         }
         const { session, initConfig } = await createSession(workflow, job, executorAddress, owner, prodContract, ipfsServiceUrl, accessToken);
-        initConfigs.set(job.chainId, initConfig);
+        initConfigs.push(initConfig);
         jobs.push({
             id: job.id,
             chainId: job.chainId,

--- a/src/core/execution/WorkflowExecutor.ts
+++ b/src/core/execution/WorkflowExecutor.ts
@@ -1,4 +1,4 @@
-import { Hex, createPublicClient, http, encodeFunctionData, parseAbiItem, AbiFunction, Address } from 'viem';
+import { Hex, createPublicClient, http, encodeFunctionData, Address } from 'viem';
 import {
 } from "@zerodev/sdk";
 import { createBundlerClient, createPaymasterClient, UserOperationReceipt, UserOperation } from 'viem/account-abstraction';
@@ -523,6 +523,7 @@ export async function executeJob(
     try {
         signature = await sessionKeyAccount.signUserOperation(userOperation);
     } catch (error) {
+        // eslint-disable-next-line no-console
         console.log(error);
         signature = userOperation.signature;
     }
@@ -538,13 +539,6 @@ export async function executeJob(
             } as any);
             const fees = await publicClient.estimateFeesPerGas();
             const feePerGas = BigInt(fees.maxFeePerGas);
-            const totalGasUnits =
-                estimation.preVerificationGas +
-                estimation.verificationGasLimit +
-                estimation.callGasLimit +
-                (estimation.paymasterVerificationGasLimit ?? BigInt(0)) +
-                (estimation.paymasterPostOpGasLimit ?? BigInt(0));
-            const totalGasEstimate = totalGasUnits * feePerGas;
             // Use buffered callGasLimit from userOperation
             const bufferedCallGasLimit = BigInt(userOperation.callGasLimit);
             const bufferedTotalGasUnits =

--- a/src/core/execution/WorkflowSubmitter.ts
+++ b/src/core/execution/WorkflowSubmitter.ts
@@ -1,10 +1,9 @@
 import { Workflow } from '../Workflow';
 import { IWorkflowStorage } from '../../storage/IWorkflowStorage';
 import { WorkflowContract } from '../../contracts/WorkflowContract';
-import { serialize, SerializeResult } from '../builders/WorkflowSerializer';
+import { serialize } from '../builders/WorkflowSerializer';
 import { Signer } from "@zerodev/sdk/types";
 import { UserOperationReceipt } from 'viem/account-abstraction';
-import { ValidatorStatus, validatorStatusMessage, WorkflowValidator } from '../validation/WorkflowValidator';
 import { getDittoWFRegistryAddress } from '../../utils/chainConfigProvider';
 
 export async function submitWorkflow(
@@ -22,6 +21,12 @@ export async function submitWorkflow(
     userOpHashes: UserOperationReceipt[];
 }> {
     workflow.typify();
+    // Off-chain validity backstop: the on-chain timestamp policy was removed (it made the
+    // account address non-deterministic), and the AVS gates execution by the validity window,
+    // but fail fast here too rather than submit a workflow that can never run.
+    if (workflow.isExpired()) {
+        throw new Error('Workflow validUntil is in the past; refusing to submit an already-expired workflow');
+    }
     const { data: serializedData, initConfigs } = await serialize(workflow, executorAddress, owner, prodContract, ipfsServiceUrl, switchChain, accessToken);
     const ipfsHash = await storage.upload(serializedData);
 
@@ -48,7 +53,7 @@ export async function submitWorkflow(
         const sessionAccountAddress = getSessionAccountAddress((serializedData as any).workflow?.jobs?.[i] || (serializedData as any).jobs?.[i]);
         const receipt = await workflowContract.createWorkflow(
             ipfsHash, owner, job.chainId, ipfsServiceUrl, usePaymaster, accessToken,
-            initConfigs.get(job.chainId),
+            initConfigs[i],
             sessionAccountAddress,
         );
         userOpHashes.push(receipt);

--- a/src/core/validation/WorkflowValidator.ts
+++ b/src/core/validation/WorkflowValidator.ts
@@ -6,9 +6,7 @@ import { deserializePermissionAccount } from '@zerodev/permissions'
 import { toECDSASigner } from '@zerodev/permissions/signers'
 import { getChainConfig } from '../../utils/chainConfigProvider'
 import { entryPointVersion } from '../../utils/constants'
-import { buildPolicies } from '../builders/PermissionBuilder'
 import { OnchainConditionOperator } from '../types'
-import { createSession } from '../builders/SessionService'
 import { authHttpConfig } from '../../utils/httpTransport'
 
 export enum ValidatorStatus {
@@ -150,6 +148,7 @@ export class WorkflowValidator {
                         }
                     }
                 } catch (error) {
+                    // eslint-disable-next-line no-console
                     console.log(error)
                     statuses.add(ValidatorStatus.InvalidStep)
                     errors.push(`invalid abi or args in step of job ${job.id}`)

--- a/src/utils/chainConfigProvider.ts
+++ b/src/utils/chainConfigProvider.ts
@@ -7,7 +7,7 @@ export class StatelessChainConfigProvider {
         if (!ipfsServiceUrl) {
             throw new Error('Ipfs Service URL is not set')
         }
-        var config: Record<number, ChainConfig> = {}
+        const config: Record<number, ChainConfig> = {}
         for (const chain of [...PROD_CHAINS, ...TEST_CHAINS]) {
             config[chain.id] = {
                 chainId: chain.id,

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,5 +1,5 @@
 import { parseAbiItem, AbiFunction } from 'viem'
-import { baseSepolia, sepolia, base, mainnet, arbitrum, polygon, optimism } from 'viem/chains'
+import { baseSepolia, sepolia, base, mainnet, arbitrum, polygon } from 'viem/chains'
 
 export enum ChainId {
     SEPOLIA = 11155111,
@@ -11,7 +11,9 @@ export enum ChainId {
     MAINNET = 1,
 }
 
-export const PROD_CHAINS = [base, mainnet, arbitrum, polygon, optimism]
+// NOTE: Optimism is intentionally excluded — the Ditto AVS stack (Attestation Center,
+// hook, DittoPolicy) is not deployed there. Add it back only once the policy exists on-chain.
+export const PROD_CHAINS = [base, mainnet, arbitrum, polygon]
 export const TEST_CHAINS = [sepolia, baseSepolia]
 
 export const DittoWFRegistryAbi = [

--- a/test/account-derivation.integration.test.ts
+++ b/test/account-derivation.integration.test.ts
@@ -77,9 +77,38 @@ maybe('v4 account derivation determinism (integration — needs DITTO_IPFS_SERVI
       plugins: { sudo: ownerValidator },
       entryPoint,
       kernelVersion: KERNEL_V3_3,
-      initConfig: initConfigs.get(job.chainId),
+      initConfig: initConfigs[0],
     });
 
     expect(registering.address.toLowerCase()).toEqual(sessionAccount);
+  });
+
+  // Regression for the per-chain initConfig collision: two jobs on the same chain must each
+  // keep their own initConfig (one per job, by index) — not collapse to a single per-chain entry.
+  test('multi-job same-chain: each job keeps its own initConfig (no collision)', async () => {
+    const SECOND_FEED = '0x694AA1769357215DE4FAC081bf1f309aDC325306' as const; // distinct Base Sepolia target
+    const wf = WorkflowBuilder.create(addressToEmptyAccount(owner.address))
+      .addCronTrigger('*/2 * * * *')
+      .setCount(5)
+      .setInterval(120)
+      .setValidAfter(new Date(ANCHOR))
+      .setValidUntil(new Date(ANCHOR + 60 * 60 * 1000))
+      .addJob(
+        JobBuilder.create('job-A').setChainId(ChainId.BASE_SEPOLIA)
+          .addStep({ target: CHAINLINK_FEED, abi: 'latestRoundData()', args: [], value: BigInt(0) }).build(),
+      )
+      .addJob(
+        JobBuilder.create('job-B').setChainId(ChainId.BASE_SEPOLIA)
+          .addStep({ target: SECOND_FEED, abi: 'latestRoundData()', args: [], value: BigInt(0) }).build(),
+      )
+      .build();
+    wf.typify();
+
+    const { data, initConfigs } = await serialize(wf, EXECUTOR, owner, false, IPFS_SERVICE_URL!);
+
+    expect(initConfigs.length).toBe(2); // one per job, not collapsed to a single per-chain entry
+    const accA = decodeSessionAccount(data.workflow.jobs[0].session);
+    const accB = decodeSessionAccount(data.workflow.jobs[1].session);
+    expect(accB).not.toEqual(accA); // different call targets → different session accounts
   });
 });


### PR DESCRIPTION
Addresses an external review of the v4 path (after #78/#79). All five findings verified against code/chain before fixing.

## P1 — multi-job same-chain registration break (correctness)
`WorkflowSerializer` stored `initConfigs` as `Map<chainId, …>`, so a second job on the same chain overwrote the first's initConfig, while each job still carried its own distinct session account. `WorkflowSubmitter` then paired job *i*'s session account with the *last* job's initConfig → registering ≠ executing → `markRun` (`onlyWorkflowOwner`) reverts for every job but the last.
**Fix:** `initConfigs` is now `0x…[][]` (one per job, aligned by index); the submitter uses `initConfigs[i]`. Added a **multi-job same-chain regression test** (passes live on Base Sepolia: `initConfigs.length === 2`, distinct accounts).

## P1 — Optimism prod policy missing (config)
`PROD_CHAINS` included `optimism`, but the v4 DittoPolicy `0x5E85C2AC…` has **0 bytes on Optimism** (no AC/hook/policy deployed there). **Fix:** removed `optimism` from `PROD_CHAINS` with a note to re-add once deployed.

## P2 — validity window enforcement (defense-in-depth)
On-chain expiry was intentionally removed in #79 (it made the account address non-deterministic), and the AVS gates execution by the window (`simulator db` query). But `Workflow.isExpired()` was dead code. **Fix:** wired `isExpired()` into `submitWorkflow` as a fail-fast backstop so an already-expired workflow is rejected before submit.

## P2 — CI didn't protect the PRs
`ci.yml` triggered on `main`; the default branch is `master`, so **no checks ran** on #78/#79, and it didn't run tests. **Fix:** target `master` and add `npm test`.

## P3 — lint failing (17 errors)
Cleared all 17 eslint errors: unused imports orphaned by the v4 work, a dead arg-coercion helper chain, a stray unused gas-estimate calc, `var`→`const`, empty `catch` blocks, and `console` disables. (`no-explicit-any` warnings remain — pre-existing, non-blocking.)

## Verification
`npm run lint` → 0 errors · `npm run build` → clean · `npm test` → **5/5 pass** (2 offline + 3 live Base Sepolia, including the new multi-job regression test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)